### PR TITLE
Add basic support for multi-whitespace installs

### DIFF
--- a/install/GarrysMod/vrmod_installer.bat
+++ b/install/GarrysMod/vrmod_installer.bat
@@ -20,15 +20,18 @@ if not defined steam_dir (
 	exit
 )
 if exist "%steam_dir%\steamapps\appmanifest_4000.acf" set "gmod_dir=%steam_dir%\steamapps\common\GarrysMod"
-for /f "usebackq tokens=2 skip=4" %%A in ("%steam_dir%\steamapps\libraryfolders.vdf") do (
-  if exist "%%~A\steamapps\appmanifest_4000.acf" set "gmod_dir=%%~A\steamapps\common\GarrysMod"
+for /f "usebackq tokens=2,3,4 skip=4" %%A in ("%steam_dir%\steamapps\libraryfolders.vdf") do (
+    if exist "%%~A\steamapps\appmanifest_4000.acf" set "gmod_dir=%%~A\steamapps\common\GarrysMod"
+    if exist "%%~A %%~B\steamapps\appmanifest_4000.acf" set "gmod_dir=%%~A %%~B\steamapps\common\GarrysMod"
+    if exist "%%~A %%~B %%~C\steamapps\appmanifest_4000.acf" set "gmod_dir=%%~A %%~B %%~C\steamapps\common\GarrysMod"
 )
 if not defined gmod_dir (
 	echo "GMod installation path not found"
 	pause
 	exit
+) else (
+	set "gmod_dir=%gmod_dir:"=%"
 )
-
 echo Game folder: %gmod_dir%
 echo Make sure Garry's Mod is not running before proceeding.
 echo.


### PR DESCRIPTION
This PR adds rudimentary support for locating and installing VRMod across multiple drives when the directory contains multiple spaces.

Previously, this search would get to "C:\Program" and immediately try to match that.  Now, if that fails, it will match "C:\Program Files", then "C:\Program Files (x86)" (most common install route) as well.  Additionally, some quote stripping is performed afterward to ensure no artifacts from this method of retrieval are passed into the gmod_dir variable.

This patch isn't very significant for users who install to C, but for people with games across multiple drives (like me) this helps to more accurately locate the install automatically.

![image](https://user-images.githubusercontent.com/57429754/235234632-41d3b0cc-da9c-4d32-a064-ec4692935b57.png)
